### PR TITLE
prevent duplicate lint runs in prs, disable azure preview for prs

### DIFF
--- a/.github/workflows/azure-static-web-apps-white-island-0dae88c00.yml
+++ b/.github/workflows/azure-static-web-apps-white-island-0dae88c00.yml
@@ -4,10 +4,6 @@ on:
   push:
     branches:
       - development
-  pull_request:
-    types: [opened, synchronize, reopened, closed]
-    branches:
-      - development
 
 jobs:
   build_and_deploy_job:

--- a/.github/workflows/lint-checker.yml
+++ b/.github/workflows/lint-checker.yml
@@ -2,6 +2,10 @@ name: Frontend Lint Checker
 
 on:
   push:
+    branches:
+      - '**'            # Match all branches
+      - '!production'   # Exclude main branch
+      - '!development'  # Exclude develop branch
     paths:
       - 'frontend/**'
   pull_request:

--- a/.github/workflows/lint-checker.yml
+++ b/.github/workflows/lint-checker.yml
@@ -1,7 +1,7 @@
 name: Frontend Lint Checker
 
 on:
-  pull_request:
+  push:
     paths:
       - 'frontend/**'
 

--- a/.github/workflows/lint-checker.yml
+++ b/.github/workflows/lint-checker.yml
@@ -1,7 +1,7 @@
 name: Frontend Lint Checker
 
 on:
-  push:
+  pull_request:
     paths:
       - 'frontend/**'
 

--- a/.github/workflows/lint-checker.yml
+++ b/.github/workflows/lint-checker.yml
@@ -1,13 +1,6 @@
 name: Frontend Lint Checker
 
 on:
-  push:
-    branches:
-      - '**'            # Match all branches
-      - '!production'   # Exclude main branch
-      - '!development'  # Exclude develop branch
-    paths:
-      - 'frontend/**'
   pull_request:
     paths:
       - 'frontend/**'

--- a/.github/workflows/lint-checker.yml
+++ b/.github/workflows/lint-checker.yml
@@ -2,12 +2,10 @@ name: Frontend Lint Checker
 
 on:
   push:
-    branches:
-      - '**'            # Match all branches
-      - '!production'   # Exclude main branch
-      - '!development'  # Exclude develop branch
     paths:
       - 'frontend/**'
+    branches-ignore:
+      - 'refs/pull/**'  # Ignore PR branches to prevent double run
   pull_request:
     paths:
       - 'frontend/**'

--- a/.github/workflows/lint-checker.yml
+++ b/.github/workflows/lint-checker.yml
@@ -2,10 +2,12 @@ name: Frontend Lint Checker
 
 on:
   push:
+    branches:
+      - '**'            # Match all branches
+      - '!production'   # Exclude main branch
+      - '!development'  # Exclude develop branch
     paths:
       - 'frontend/**'
-    branches-ignore:
-      - 'refs/pull/**'  # Ignore PR branches to prevent double run
   pull_request:
     paths:
       - 'frontend/**'

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,3 +1,3 @@
 export default function Page() {
-  return <div>Home Page</div>;
+  return <div>Home Pageaa</div>;
 }

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,3 +1,3 @@
 export default function Page() {
-  return <div>Home Page Test Double Run</div>;
+  return <div>Home Page</div>;
 }

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,3 +1,3 @@
 export default function Page() {
-  return <div>Home Page</div>;
+  return <div>Home Page Test Double Run</div>;
 }

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,3 +1,3 @@
 export default function Page() {
-  return <div>Home Pageaa</div>;
+  return <div>Home Page</div>;
 }


### PR DESCRIPTION
- run lint only in PRs (ok for us as you cant directly commit to dev)
- stop azure from deploying previews in favor of coolify (limit of 3 previews which is useless + its slow af)