### PR TITLE
Frontend/michael/sign in UI

### DIFF
--- a/frontend/src/app/sign-in/page.tsx
+++ b/frontend/src/app/sign-in/page.tsx
@@ -77,8 +77,16 @@ export default function SignInPage() {
           <Button
             variant="default"
             onClick={() => signIn("google", { callbackUrl })}
+            leftSection={
+              <svg width="18" height="18" viewBox="0 0 48 48">
+                <path fill="#EA4335" d="M24 9.5c3.54 0 6.71 1.22 9.21 3.6l6.85-6.85C35.9 2.38 30.47 0 24 0 14.62 0 6.51 5.38 2.56 13.22l7.98 6.19C12.43 13.72 17.74 9.5 24 9.5z"/>
+                <path fill="#4285F4" d="M46.98 24.55c0-1.57-.15-3.09-.38-4.55H24v9.02h12.94c-.58 2.96-2.26 5.48-4.78 7.18l7.73 6c4.51-4.18 7.09-10.36 7.09-17.65z"/>
+                <path fill="#FBBC05" d="M10.53 28.59a14.5 14.5 0 0 1 0-9.18l-7.98-6.19a24.01 24.01 0 0 0 0 21.56l7.98-6.19z"/>
+                <path fill="#34A853" d="M24 48c6.48 0 11.93-2.13 15.89-5.81l-7.73-6c-2.15 1.45-4.92 2.3-8.16 2.3-6.26 0-11.57-4.22-13.47-9.91l-7.98 6.19C6.51 42.62 14.62 48 24 48z"/>
+              </svg>
+            }
           >
-            Continue with Google
+            Sign in with Google
           </Button>
         </form>
       </Card>

--- a/frontend/src/app/sign-up/page.tsx
+++ b/frontend/src/app/sign-up/page.tsx
@@ -74,8 +74,16 @@ export default function SignUpPage() {
           <Button
             variant="default"
             onClick={() => signIn("google", { callbackUrl: "/my-applications" })}
+            leftSection={
+              <svg width="18" height="18" viewBox="0 0 48 48">
+                <path fill="#EA4335" d="M24 9.5c3.54 0 6.71 1.22 9.21 3.6l6.85-6.85C35.9 2.38 30.47 0 24 0 14.62 0 6.51 5.38 2.56 13.22l7.98 6.19C12.43 13.72 17.74 9.5 24 9.5z"/>
+                <path fill="#4285F4" d="M46.98 24.55c0-1.57-.15-3.09-.38-4.55H24v9.02h12.94c-.58 2.96-2.26 5.48-4.78 7.18l7.73 6c4.51-4.18 7.09-10.36 7.09-17.65z"/>
+                <path fill="#FBBC05" d="M10.53 28.59a14.5 14.5 0 0 1 0-9.18l-7.98-6.19a24.01 24.01 0 0 0 0 21.56l7.98-6.19z"/>
+                <path fill="#34A853" d="M24 48c6.48 0 11.93-2.13 15.89-5.81l-7.73-6c-2.15 1.45-4.92 2.3-8.16 2.3-6.26 0-11.57-4.22-13.47-9.91l-7.98 6.19C6.51 42.62 14.62 48 24 48z"/>
+              </svg>
+            }
           >
-            Continue with Google
+            Sign up with Google
           </Button>
         </form>
       </Card>

--- a/frontend/src/components/layout/nav-links.tsx
+++ b/frontend/src/components/layout/nav-links.tsx
@@ -61,7 +61,7 @@ export default function NavLinks() {
           </Menu.Dropdown>
         </Menu>
       ) : (
-        <Link className={linkClass("/sign-in")} href="/sign-in">
+        <Link className={`${linkClass("/sign-in")} whitespace-nowrap`} href="/sign-in">
           Sign in
         </Link>
       )}


### PR DESCRIPTION
## Summary
- Added the official Google "G" SVG logo to the **Sign in with Google** and **Sign up with Google** buttons on the sign-in and sign-up pages, making the OAuth option immediately recognisable to users
- Fixed the **Sign in** nav link wrapping onto two lines on certain screen widths by applying `whitespace-nowrap`

## Changes
| File | Change |
|------|--------|
| `src/app/sign-in/page.tsx` | Added Google G SVG icon to the Google sign-in button |
| `src/app/sign-up/page.tsx` | Added Google G SVG icon to the Google sign-up button |
| `src/components/layout/nav-links.tsx` | Added `whitespace-nowrap` to prevent "Sign in" link wrapping |
## Notes
- The Google logo is implemented as an **inline SVG** (no external image dependency) using Google's official brand colours (`#EA4335`, `#4285F4`, `#FBBC05`, `#34A853`). It scales cleanly at any size.
- No new dependencies introduced.
- Both changes are purely cosmetic — no logic, auth flow, or data handling was modified.

## Screenshots

before:
<img width="1339" height="530" alt="image" src="https://github.com/user-attachments/assets/45a6911f-fd40-4950-8aac-336d7bd4c6c2" />


after:
<img width="1306" height="546" alt="image" src="https://github.com/user-attachments/assets/781f14f4-66e1-41c4-bab1-3c715332d4b4" />

