### PR TITLE
fix(frontend): scope Turbopack to the app directory

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -9,7 +9,12 @@ const nextConfig: NextConfig = {
   // package-lock.json makes Next infer the repo root as the tracing root and
   // nest the standalone output under frontend/, breaking the Dockerfile CMD.
   outputFileTracingRoot: path.join(__dirname),
+  turbopack: {
+    root: path.resolve(__dirname),
+  },
+  
   serverExternalPackages: ["mongodb", "pino", "pino-pretty"],
+  
 };
 
 export default nextConfig;


### PR DESCRIPTION
Set turbopack.root explicitly to prevent Next.js from inferring the repository root from multiple lockfiles, reducing unnecessary file watching and dev cache growth.